### PR TITLE
[nrf fromlist] boards: nrf9160dk_nrf9160: Correct arduino_spi definition

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
@@ -91,36 +91,19 @@
 		};
 	};
 
-	spi1_default: spi1_default {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 12)>,
-				<NRF_PSEL(SPIM_MISO, 0, 11)>;
-		};
-	};
-
-	spi1_sleep: spi1_sleep {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 12)>,
-				<NRF_PSEL(SPIM_MISO, 0, 11)>;
-			low-power-enable;
-		};
-	};
-
 	spi3_default: spi3_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 18)>,
-				<NRF_PSEL(SPIM_MISO, 0, 17)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MISO, 0, 12)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 11)>;
 		};
 	};
 
 	spi3_sleep: spi3_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 18)>,
-				<NRF_PSEL(SPIM_MISO, 0, 17)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MISO, 0, 12)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 11)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -174,7 +174,7 @@
 };
 
 arduino_serial: &uart1 {
-	/* Cannot be used together with spi1, hence disabled by default. */
+	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
@@ -202,17 +202,10 @@ arduino_i2c: &i2c2 {
 	pinctrl-names = "default", "sleep";
 };
 
-arduino_spi: &spi1 {
-	/* Cannot be used together with uart1, hence disabled by default. */
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
-	pinctrl-0 = <&spi1_default>;
-	pinctrl-1 = <&spi1_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
-&spi3 {
+arduino_spi: &spi3 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 	pinctrl-0 = <&spi3_default>;
 	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common_0_14_0.dtsi
@@ -37,34 +37,12 @@
 	};
 };
 
-&pinctrl {
-	spi3_default_v14: spi3_default_v14 {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 11)>,
-				<NRF_PSEL(SPIM_MISO, 0, 12)>;
-		};
-	};
-
-	spi3_sleep_v14: spi3_sleep_v14 {
-		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 11)>,
-				<NRF_PSEL(SPIM_MISO, 0, 12)>;
-			low-power-enable;
-		};
-	};
-};
-
 &spi3 {
-	status = "okay";
-	pinctrl-0 = <&spi3_default_v14>;
-	pinctrl-1 = <&spi3_sleep_v14>;
-	pinctrl-names = "default", "sleep";
-	cs-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
-	mx25r64: mx25r6435f@0 {
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>, /* D10 */
+		   <&gpio0 25 GPIO_ACTIVE_LOW>;
+	mx25r64: mx25r6435f@1 {
 		compatible = "jedec,spi-nor";
-		reg = <0>;
+		reg = <1>;
 		spi-max-frequency = <8000000>;
 		label = "MX25R64";
 		jedec-id = [c2 28 17];


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/48621

This is a follow-up to commit 854129902057ad236acc8ff3b091ededc86f922c.

The arduino_spi definition introduced in the above commit is incorrect
because the spi1 MOSI and MISO pins are swapped and spi1 uses the same
pins (P0.13, P0.12, and P0.11) that are assigned to spi3 when building
for board revision 0.14.0 and above.
This commit actually reverts the changes made to dts files in the
commit mentioned above and instead it adds the arduino_spi label
to spi3 and assigns the proper pins to this instance in the default
dts file. And in the overlay for revision 0.14.0 it just adds another
CS line to spi3 (the SPIM pins are by default configured correctly)
so that this instance can be used for communication with the exernal
flash.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>